### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,8 +7,8 @@
         "data operations"
     ],
     "description": "Assigns tags (train/val) to images. Training apps will use these tags to split data.",
-    "docker_image": "supervisely/data-operations:6.73.492",
-    "instance_version": "6.15.35",
+    "docker_image": "supervisely/data-operations:6.73.564",
+    "instance_version": "6.15.60",
     "main_script": "src/tag_train_val_test.py",
     "modal_template": "src/modal.html",
     "modal_template_state": {},

--- a/config.json
+++ b/config.json
@@ -1,27 +1,27 @@
 {
-    "name": "Assign train/val tags to images",
-    "type": "app",
-    "categories": [
-        "images",
-        "annotation transformation",
-        "data operations"
+  "name": "Assign train/val tags to images",
+  "type": "app",
+  "categories": [
+    "images",
+    "annotation transformation",
+    "data operations"
+  ],
+  "description": "Assigns tags (train/val) to images. Training apps will use these tags to split data.",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/tag_train_val_test.py",
+  "modal_template": "src/modal.html",
+  "modal_template_state": {},
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "isolate": true,
+  "icon": "https://i.imgur.com/f4HAo01.png",
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "images_project"
     ],
-    "description": "Assigns tags (train/val) to images. Training apps will use these tags to split data.",
-    "docker_image": "supervisely/data-operations:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/tag_train_val_test.py",
-    "modal_template": "src/modal.html",
-    "modal_template_state": {},
-    "gui_template": "src/gui.html",
-    "task_location": "workspace_tasks",
-    "isolate": true,
-    "icon": "https://i.imgur.com/f4HAo01.png",
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "images_project"
-        ],
-        "context_category": "Training data"
-    },
-    "poster": "https://user-images.githubusercontent.com/48245050/182362563-ca05f75c-0480-4ba1-8e4f-f53e11238d4f.png"
+    "context_category": "Training data"
+  },
+  "poster": "https://user-images.githubusercontent.com/48245050/182362563-ca05f75c-0480-4ba1-8e4f-f53e11238d4f.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.492
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
